### PR TITLE
fix: do not clobber `module.exports`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ $ npm install --save axe-selector
 ```js
 import getSelector from 'axe-selector'
 
+// or with CommonJS:
+const getSelector = require('axe-selector').default
+
 const el = getDOMElementSomehow()
 
 // Generate a selector.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,3 @@ import getSelector, { GetSelectorOptions } from './getSelector'
 
 export default getSelector
 export { GetSelectorOptions }
-
-// CommonJS support.
-module.exports = getSelector


### PR DESCRIPTION
This patch allows the "default" export to work as expected. I don't think this should be considered a breaking change, since this never worked as expected.